### PR TITLE
Improve unitary tests

### DIFF
--- a/src/pyepri/utils.py
+++ b/src/pyepri/utils.py
@@ -1,5 +1,5 @@
-"""This module contains standard operators usually involved in signal
-or image processing.
+"""This module contains standard functions, like operators usually
+involved in signal or image processing.
 
 """
 import pyepri.checks as checks
@@ -58,7 +58,7 @@ def grad1d(u, backend=None, notest=False):
     return G
 
 def div1d(P, backend=None, notest=False):
-    """discrete divergence of a mono-dimensional array (opposite adjoint of grad1d).
+    """Discrete divergence of a mono-dimensional array (opposite adjoint of grad1d).
     
     Parameters
     ----------
@@ -168,7 +168,7 @@ def grad2d(u, backend=None, notest=False):
     return G
 
 def div2d(P, backend=None, notest=False):
-    """discrete divergence of a 2D field vector (opposite adjoint of grad2d).
+    """Discrete divergence of a 2D field vector (opposite adjoint of grad2d).
     
     Parameters
     ----------
@@ -284,7 +284,7 @@ def grad3d(u, backend=None, notest=False):
     return G
 
 def div3d(P, backend=None, notest=False):
-    """discrete divergence of a 3D field vector (opposite adjoint of grad3d).
+    """Discrete divergence of a 3D field vector (opposite adjoint of grad3d).
 
     Parameters
     ----------
@@ -350,6 +350,60 @@ def div3d(P, backend=None, notest=False):
     # return output divergence
     return div
 
+def _relerr_(u, v, backend=None, nrm=1., notest=False):
+    """Compute relative error between two arrays.    
+    
+    Parameters
+    ----------
+    
+    u : array_like (with type `backend.cls`)
+        First input array.
+    
+    v : array_like (with type `backend.cls`)
+        Second input array.
+    
+    backend : <class 'pyepri.backends.Backend'> or None, optional
+        A numpy, cupy or torch backend (see :py:mod:`pyepri.backends`
+        module).
+        
+        When backend is None, a default backend is inferred from the
+        input arrays ``u`` and ``v``.
+    
+    nrm : float, optional
+        A normalization factor to be applied to both input array
+        (useful to avoid underflow or overflow issues in the
+        computation of the relative error). If not given, ``nrm`` will
+        be taken equal to one over the infinite norm of ``u``, i.e.,
+        ``nrm = 1. / ||u||_inf``.
+    
+    notest : bool, optional
+        Set ``notest=True`` to disable consistency checks.
+        
+    Return
+    ------
+    
+    rel : float
+        The relative error ``||nrm * u - nrm * v|| / ||nrm * u||``
+        where ``||.||`` denotes the l2 norm.
+
+    """   
+    # backend inference (if necessary)
+    if backend is None:
+        backend = checks._backend_inference_(u=u, v=v)
+    
+    # consistency checks
+    if not notest:
+        checks._check_backend_(backend, u=u, v=v)
+        checks._check_dtype_(u.dtype, v=v)
+        checks._check_ndim_(u.ndim, v=v)
+    
+    # deal with nrm default value
+    if nrm is None:
+        nrm = 1. / backend.abs(u).max().item()
+        
+    # compute & return relative error between nrm * u and nrm * v
+    rel = backend.sqrt((backend.abs(nrm * u - nrm * v)**2).sum() / (backend.abs(nrm * u)**2).sum()).item()
+    return rel
 
 def _check_nd_inputs_(ndims, backend, u=None, P=None):
     """Factorized consistency checks for functions in the :py:mod:`pyepri.utils` submodule."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+import importlib.util
+
+
+def pytest_addoption(parser):
+    parser.addoption("--nruns",
+                     action="store",
+                     type=int,
+                     default=100,
+                     help="number of runs (or passes) within each test")
+    parser.addoption("--tol",
+                     action="store",
+                     type=float,
+                     default=1000,
+                     help="tolerance parameter (check relative error <= tol * eps)")
+    parser.addoption("--libname",
+                     action="append",
+                     type=str,
+                     choices=['numpy', 'torch-cpu', 'torch-cuda', 'cupy'],
+                     default=[],
+                     help="use a specific library (backend) (must be in ['numpy', 'torch-cpu', 'torch-cuda', 'cupy'])")
+    parser.addoption("--dtype",
+                     action="append",
+                     type=str,
+                     choices=['float32', 'float64'],
+                     default=[],
+                     help="use a specific datatype (must be in ['float32', 'float64'])")
+
+def pytest_generate_tests(metafunc):
+    
+    # deal with nruns option
+    if 'nruns' in metafunc.fixturenames:
+        nruns = metafunc.config.getoption('nruns')
+        metafunc.parametrize('nruns', [nruns])
+        
+    # deal with tol option
+    if 'tol' in metafunc.fixturenames:
+        tol = metafunc.config.getoption('tol')
+        metafunc.parametrize('tol', [tol])
+    
+    # deal with dtype option
+    if 'dtype' in metafunc.fixturenames:        
+        dtype = metafunc.config.getoption('dtype')        
+        metafunc.parametrize('dtype', ["float32", "float64"] if not dtype else dtype)
+    
+    if 'libname' in metafunc.fixturenames:
+        
+        # get requested libname(s)
+        libname = metafunc.config.getoption('libname')
+        if not libname:            
+            # retrieve all available backends
+            L = ['numpy']
+            if importlib.util.find_spec('torch') is not None:
+                L += ['torch-cpu']
+                import torch
+                if torch.cuda.is_available():
+                    L += ['torch-cuda']
+            if importlib.util.find_spec('cupy') is not None:
+                L += ['cupy']
+                import cupy
+        else:
+            # keep only the requested backend
+            L = libname
+        
+        # generate tests
+        metafunc.parametrize('libname', L)    

--- a/tests/test_2d_monosrc.py
+++ b/tests/test_2d_monosrc.py
@@ -24,16 +24,16 @@ def test_proj2d_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(16*backend.rand(1)[0])
-        N2 = 1 + int(16*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(16 * backend.rand(1)[0])
+        N2 = 1 + int(16 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(2, Nproj, dtype=dtype)
         
@@ -70,16 +70,16 @@ def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(16*backend.rand(1)[0])
-        N2 = 1 + int(16*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(16 * backend.rand(1)[0])
+        N2 = 1 + int(16 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(2, Nproj, dtype=dtype)
         
@@ -117,16 +117,16 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(16*backend.rand(1)[0])
-        N2 = 1 + int(16*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(16 * backend.rand(1)[0])
+        N2 = 1 + int(16 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h1 = backend.rand(Nb, dtype=dtype)
         h2 = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(2, Nproj, dtype=dtype)
@@ -161,16 +161,16 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(16*backend.rand(1)[0])
-        N2 = 1 + int(16*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(16 * backend.rand(1)[0])
+        N2 = 1 + int(16 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(2, Nproj, dtype=dtype)
         
@@ -202,7 +202,7 @@ def test_proj2d_and_backproj2d_matrices(libname, dtype, nruns, tol):
         backend = backends.create_torch_backend('cuda')
     elif libname == 'cupy': 
         backend = backends.create_cupy_backend()
-        
+    
     # retrieve machine epsilon
     #eps = backend.lib.finfo(backend.str_to_lib_dtypes[dtype]).eps
     eps = 1e-15 if dtype == 'float64' else 1e-6
@@ -240,14 +240,14 @@ def test_proj2d_and_backproj2d_matrices(libname, dtype, nruns, tol):
             v[col-1] = 0
             v[col] = 1
             M[:,col] = arr_to_vec(A(vec_to_arr(v, (N1, N2))))
-
+        
         # evaluate adjA(y) by matrix-vector multiplication
         Mt = backend.transpose(M)
         adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2))
         rel = utils._relerr_(adjAy1, adjAy2, backend=backend, notest=True)
         assert rel < tol * eps
-        
-    
+
+
 def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
@@ -271,16 +271,16 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(16*backend.rand(1)[0])
-        N2 = 1 + int(16*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(16 * backend.rand(1)[0])
+        N2 = 1 + int(16 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(2, Nproj, dtype=dtype)
         
@@ -300,9 +300,6 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
         phi = monosrc.compute_2d_toeplitz_kernel(B, h, h, delta, fgrad, (2*N1, 2*N2), backend=backend, eps=eps, rfft_mode=rfft_mode, nodes=nodes)
         
         # apply 2D convolution
-        #u_large = backend.zeros([2*N1, 2*N2], dtype=backend.lib_to_str_dtypes[u.dtype])
-        #u_large[:N1, :N2] = u
-        #out = backend.irfft2(backend.rfft2(phi) * backend.rfft2(u_large), s=u_large.shape)[N1::,N2::]
         out = monosrc.apply_2d_toeplitz_kernel(u, backend.rfft2(phi), backend=backend)
         
         # check that `adjAAu` and `out` are close to each other

--- a/tests/test_2d_monosrc.py
+++ b/tests/test_2d_monosrc.py
@@ -1,24 +1,9 @@
-import pytest
 import pyepri.backends as backends
 import pyepri.monosrc as monosrc
 import importlib.util
 import numpy as np
 
-libname = ['numpy']
-
-if importlib.util.find_spec('torch') is not None:
-    import torch
-    libname += ['torch-cpu']
-    if torch.cuda.is_available():
-        libname += ['torch-cuda']
-if importlib.util.find_spec('cupy') is not None:
-    import cupy
-    libname += ['cupy']
-
-
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_proj2d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -64,9 +49,7 @@ def test_proj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
         
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -113,9 +96,7 @@ def test_backproj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
         
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -159,9 +140,7 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
         
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns=100, tol=1000):
+def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -232,9 +211,7 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns=100, tol=1000):
     assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_2d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
+def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':

--- a/tests/test_2d_monosrc.py
+++ b/tests/test_2d_monosrc.py
@@ -189,28 +189,65 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
         inprod2 = (x * adjAy).sum()
         rel = abs(1 - inprod1 / inprod2)
         assert rel < tol * eps
-        
-    # compute matricial representation of A and its adjoint (use the
-    # last generated dataset)
-    A = lambda x : monosrc.proj2d(x, delta, B, h, fgrad, backend=backend, rfft_mode=rfft_mode, eps=eps)
-    arr_to_vec = lambda arr : arr.reshape((-1,))
-    vec_to_arr = lambda vec, shape: vec.reshape(shape)
-    m = Nproj * Nb
-    n = N1 * N2
-    M = backend.zeros([m, n], dtype=dtype)
-    v = backend.zeros((n,), dtype=dtype)
-    for col in range(n):
-        v[col-1] = 0
-        v[col] = 1
-        M[:,col] = arr_to_vec(A(vec_to_arr(v, (N1, N2))))
-        
-    # evaluate adjA(y) by matrix-vector multiplication
-    Mt = backend.transpose(M)
-    adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2))
-    rel = utils._relerr_(adjAy, adjAy2, backend=backend, notest=True)
-    assert rel < tol * eps
 
 
+def test_proj2d_and_backproj2d_matrices(libname, dtype, nruns, tol):
+    
+    # create backend
+    if libname == 'numpy':
+        backend = backends.create_numpy_backend()
+    elif libname == 'torch-cpu': 
+        backend = backends.create_torch_backend('cpu')
+    elif libname == 'torch-cuda': 
+        backend = backends.create_torch_backend('cuda')
+    elif libname == 'cupy': 
+        backend = backends.create_cupy_backend()
+        
+    # retrieve machine epsilon
+    #eps = backend.lib.finfo(backend.str_to_lib_dtypes[dtype]).eps
+    eps = 1e-15 if dtype == 'float64' else 1e-6
+    
+    # check adjointness for the monosrc.proj2d and monosrc.backproj2d
+    # via matrix representation over very small datasets
+    for id in range(nruns):
+        
+        # compute a very small dataset
+        N1 = 1 + int(4 * backend.rand(1)[0])
+        N2 = 1 + int(4 * backend.rand(1)[0])
+        Nproj = 1 + int(5 * backend.rand(1)[0])
+        Nb = 2 + int(5 * backend.rand(1)[0])
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
+        dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
+        delta = float(10. * eps + backend.rand(1)[0])
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
+        fgrad = backend.rand(2, Nproj, dtype=dtype)
+        h = backend.rand(Nb, dtype=dtype)
+        y = backend.rand(Nproj, Nb, dtype=dtype)
+        
+        # evaluate adjA(y) using monosrc.backproj2d        
+        rfft_mode = backend.rand(1)[0] > 0.5
+        adjAy1 = monosrc.backproj2d(y, delta, B, h, fgrad, backend=backend, out_shape=(N1, N2), rfft_mode=rfft_mode, eps=eps)
+        
+        # compute matricial representation of A and its adjoint over this dataset
+        A = lambda x : monosrc.proj2d(x, delta, B, h, fgrad, backend=backend, rfft_mode=rfft_mode, eps=eps)
+        arr_to_vec = lambda arr : arr.reshape((-1,))
+        vec_to_arr = lambda vec, shape: vec.reshape(shape)
+        m = Nproj * Nb
+        n = N1 * N2
+        M = backend.zeros([m, n], dtype=dtype)
+        v = backend.zeros((n,), dtype=dtype)
+        for col in range(n):
+            v[col-1] = 0
+            v[col] = 1
+            M[:,col] = arr_to_vec(A(vec_to_arr(v, (N1, N2))))
+
+        # evaluate adjA(y) by matrix-vector multiplication
+        Mt = backend.transpose(M)
+        adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2))
+        rel = utils._relerr_(adjAy1, adjAy2, backend=backend, notest=True)
+        assert rel < tol * eps
+        
+    
 def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend

--- a/tests/test_2d_monosrc.py
+++ b/tests/test_2d_monosrc.py
@@ -1,6 +1,6 @@
 import pyepri.backends as backends
 import pyepri.monosrc as monosrc
-import importlib.util
+import pyepri.utils as utils
 import numpy as np
 
 def test_proj2d_rfftmode(libname, dtype, nruns, tol):
@@ -45,8 +45,8 @@ def test_proj2d_rfftmode(libname, dtype, nruns, tol):
         Ax2 = monosrc.proj2d(x, delta, B, h, fgrad, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = backend.sqrt((backend.abs(Ax1 - Ax2)**2).sum() / (backend.abs(Ax1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(Ax1, Ax2, backend=backend, notest=True)
+        assert rel < tol * eps
         
 
 def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
@@ -92,8 +92,8 @@ def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
         adjAy2 = monosrc.backproj2d(y, delta, B, h, fgrad, out_shape, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = backend.sqrt((backend.abs(adjAy1 - adjAy2)**2).sum() / (backend.abs(adjAy1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(adjAy1, adjAy2, backend=backend, notest=True)
+        assert rel < tol * eps
         
 
 def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
@@ -136,8 +136,8 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         phi2 = monosrc.compute_2d_toeplitz_kernel(B, h1, h2, delta, fgrad, (2*N1, 2*N2), backend=backend, eps=eps, rfft_mode=False)
         
         # compare results
-        rel = backend.sqrt((backend.abs(phi1 - phi2)**2).sum() / (backend.abs(phi1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(phi1, phi2, backend=backend, notest=True)
+        assert rel < tol * eps
         
 
 def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
@@ -187,8 +187,8 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
         # compute inner products
         inprod1 = (Ax * y).sum()
         inprod2 = (x * adjAy).sum()
-        rel = abs(1-inprod1/inprod2)
-        assert rel < tol*eps
+        rel = abs(1 - inprod1 / inprod2)
+        assert rel < tol * eps
         
     # compute matricial representation of A and its adjoint (use the
     # last generated dataset)
@@ -207,8 +207,8 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
     # evaluate adjA(y) by matrix-vector multiplication
     Mt = backend.transpose(M)
     adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2))
-    rel = backend.sqrt((backend.abs(adjAy2 - adjAy)**2).sum() / (backend.abs(adjAy2)**2).sum())
-    assert rel < tol*eps
+    rel = utils._relerr_(adjAy, adjAy2, backend=backend, notest=True)
+    assert rel < tol * eps
 
 
 def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
@@ -269,7 +269,6 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
         out = monosrc.apply_2d_toeplitz_kernel(u, backend.rfft2(phi), backend=backend)
         
         # check that `adjAAu` and `out` are close to each other
-        #rel = backend.abs(adjAAu - out).max() / backend.sqrt((adjAAu**2).sum())
-        rel = backend.sqrt(((adjAAu - out)**2).sum()) / backend.sqrt((adjAAu**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(adjAAu, out, backend=backend, notest=True)
+        assert rel < tol * eps
         

--- a/tests/test_2d_multisrc.py
+++ b/tests/test_2d_multisrc.py
@@ -24,16 +24,16 @@ def test_proj2d_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(16*backend.rand(1)[0]), 1 + int(16*backend.rand(1)[0])) for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        Nb = 2 + int(25 * backend.rand(1)[0])
+        u_shape = [(1 + int(8 * backend.rand(1)[0]), 1 + int(8 * backend.rand(1)[0])) for j in range(K)]
+        s_shape = [(1 + int(10 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -73,16 +73,16 @@ def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(16*backend.rand(1)[0]), 1 + int(16*backend.rand(1)[0])) for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        Nb = 2 + int(25 * backend.rand(1)[0])
+        u_shape = [(1 + int(8 * backend.rand(1)[0]), 1 + int(8 * backend.rand(1)[0])) for j in range(K)]
+        s_shape = [(1 + int(10 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -122,16 +122,16 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(16*backend.rand(1)[0]), 1 + int(16*backend.rand(1)[0])) for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        Nb = 2 + int(25 * backend.rand(1)[0])
+        u_shape = [(1 + int(8 * backend.rand(1)[0]), 1 + int(8 * backend.rand(1)[0])) for j in range(K)]
+        s_shape = [(1 + int(10 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -168,16 +168,16 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(16*backend.rand(1)[0]), 1 + int(16*backend.rand(1)[0])) for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        Nb = 2 + int(25 * backend.rand(1)[0])
+        u_shape = [(1 + int(8 * backend.rand(1)[0]), 1 + int(8 * backend.rand(1)[0])) for j in range(K)]
+        s_shape = [(1 + int(10 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -227,19 +227,19 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(16*backend.rand(1)[0]), 1 + int(16*backend.rand(1)[0])) for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        Nb = 2 + int(25 * backend.rand(1)[0])
+        u_shape = [(1 + int(8 * backend.rand(1)[0]), 1 + int(8 * backend.rand(1)[0])) for j in range(K)]
+        s_shape = [(1 + int(10 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(2, s[0], dtype=dtype) for s in s_shape]
         

--- a/tests/test_2d_multisrc.py
+++ b/tests/test_2d_multisrc.py
@@ -1,24 +1,9 @@
-import pytest
 import pyepri.backends as backends
 import pyepri.multisrc as multisrc
 import importlib.util
 import numpy as np
 
-libname = ['numpy']
-
-if importlib.util.find_spec('torch') is not None:
-    import torch
-    libname += ['torch-cpu']
-    if torch.cuda.is_available():
-        libname += ['torch-cuda']
-if importlib.util.find_spec('cupy') is not None:
-    import cupy
-    libname += ['cupy']
-
-
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_proj2d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -69,9 +54,8 @@ def test_proj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = [relerr(Bu1[i], Bu2[i]) for i in range(L)]
         assert max(rel) < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -122,9 +106,8 @@ def test_backproj2d_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = [relerr(adjBs1[j], adjBs2[j]) for j in range(K)]
         assert max(rel) < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -172,9 +155,8 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = [relerr(phi1[k][j], phi2[k][j]) for k in range(K) for j in range(K)]
         assert max(rel) < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns=100, tol=1000):
+
+def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -229,9 +211,8 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns=100, tol=1000):
         rel = abs(1-inprod1/inprod2)
         assert rel < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_2d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
+
+def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':

--- a/tests/test_2d_multisrc.py
+++ b/tests/test_2d_multisrc.py
@@ -1,6 +1,6 @@
 import pyepri.backends as backends
 import pyepri.multisrc as multisrc
-import importlib.util
+import pyepri.utils as utils
 import numpy as np
 
 def test_proj2d_rfftmode(libname, dtype, nruns, tol):
@@ -17,9 +17,6 @@ def test_proj2d_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.proj2d returns the same results whenever
     # rfft_mode parameter is True or False
@@ -51,8 +48,8 @@ def test_proj2d_rfftmode(libname, dtype, nruns, tol):
         Bu2 = multisrc.proj2d(u, delta, B, h, fgrad, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = [relerr(Bu1[i], Bu2[i]) for i in range(L)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(Bu1[i], Bu2[i], backend=backend, notest=True) for i in range(L)]
+        assert max(rel) < tol * eps
 
 
 def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
@@ -69,9 +66,6 @@ def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.backproj2d returns the same results whenever
     # rfft_mode parameter is True or False
@@ -103,8 +97,8 @@ def test_backproj2d_rfftmode(libname, dtype, nruns, tol):
         adjBs2 = multisrc.backproj2d(s, delta, B, h, fgrad, u_shape, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = [relerr(adjBs1[j], adjBs2[j]) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(adjBs1[j], adjBs2[j], backend=backend, notest=True) for j in range(K)]
+        assert max(rel) < tol * eps
 
 
 def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
@@ -121,9 +115,6 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.compute_2d_toeplitz_kernels returns the same
     # results whenever rfft_mode parameter is True or False
@@ -152,8 +143,8 @@ def test_2d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         phi2 = multisrc.compute_2d_toeplitz_kernels(B, h, delta, fgrad, u_shape, backend=backend, eps=eps, rfft_mode=False)
         
         # compare results
-        rel = [relerr(phi1[k][j], phi2[k][j]) for k in range(K) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(phi1[k][j], phi2[k][j], backend=backend, notest=True) for k in range(K) for j in range(K)]
+        assert max(rel) < tol * eps
 
 
 def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
@@ -208,8 +199,8 @@ def test_proj2d_and_backproj2d_adjointness(libname, dtype, nruns, tol):
         # compute inner products
         inprod1 = sum([(Bu[i] * s[i]).sum() for i in range(L)])
         inprod2 = sum([(u[j] * adjBs[j]).sum() for j in range(K)])
-        rel = abs(1-inprod1/inprod2)
-        assert rel < tol*eps
+        rel = abs(1 - inprod1 / inprod2)
+        assert rel < tol * eps
 
 
 def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
@@ -226,9 +217,6 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # retrieve dtype precision (threshold to 1e-16)
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # denoting by B and adjB the operators associated to
     # multisrc.proj2d and multisrc.backproj2d, check that adjB(B(u))
@@ -276,6 +264,6 @@ def test_2d_toeplitz_kernel(libname, dtype, nruns, tol):
         out = multisrc.apply_2d_toeplitz_kernels(u, rfft2_phi, backend=backend)
         
         # check that `adjBBu` and `out` are close to each other
-        rel = [relerr(adjBBu[j], out[j]) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(adjBBu[j], out[j], backend=backend, notest=True) for j in range(K)]
+        assert max(rel) < tol * eps
         

--- a/tests/test_3d_monosrc.py
+++ b/tests/test_3d_monosrc.py
@@ -1,6 +1,6 @@
 import pyepri.backends as backends
 import pyepri.monosrc as monosrc
-import importlib.util
+import pyepri.utils as utils
 import numpy as np
 
 def test_proj3d_rfftmode(libname, dtype, nruns, tol):
@@ -46,8 +46,8 @@ def test_proj3d_rfftmode(libname, dtype, nruns, tol):
         Ax2 = monosrc.proj3d(x, delta, B, h, fgrad, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = backend.sqrt((backend.abs(Ax1 - Ax2)**2).sum() / (backend.abs(Ax1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(Ax1, Ax2, backend=backend, notest=True)
+        assert rel < tol * eps
 
 
 def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
@@ -94,8 +94,8 @@ def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
         adjAy2 = monosrc.backproj3d(y, delta, B, h, fgrad, out_shape, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = backend.sqrt((backend.abs(adjAy1 - adjAy2)**2).sum() / (backend.abs(adjAy1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(adjAy1, adjAy2, backend=backend, notest=True)
+        assert rel < tol * eps
 
 
 def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
@@ -139,8 +139,8 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         phi2 = monosrc.compute_3d_toeplitz_kernel(B, h1, h2, delta, fgrad, (2*N1, 2*N2, 2*N3), backend=backend, eps=eps, rfft_mode=False)
         
         # compare results
-        rel = backend.sqrt((backend.abs(phi1 - phi2)**2).sum() / (backend.abs(phi1)**2).sum())
-        assert rel < tol*eps
+        rel = utils._relerr_(phi1, phi2, backend=backend, notest=True)
+        assert rel < tol * eps
 
 
 def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
@@ -191,8 +191,8 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
         # compute inner products
         inprod1 = (Ax * y).sum()
         inprod2 = (x * adjAy).sum()
-        rel = abs(1-inprod1/inprod2)
-        assert rel < tol*eps
+        rel = abs(1 - inprod1 / inprod2)
+        assert rel < tol * eps
         
     # compute matricial representation of A and its adjoint (use the
     # last generated dataset)
@@ -211,8 +211,8 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
     # evaluate adjA(y) by matrix-vector multiplication
     Mt = backend.transpose(M)
     adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2, N3))
-    rel = backend.sqrt((backend.abs(adjAy2 - adjAy)**2).sum() / (backend.abs(adjAy2)**2).sum())
-    assert rel < tol*eps
+    rel = utils._relerr_(adjAy, adjAy2, backend=backend, notest=True)
+    assert rel < tol * eps
 
 
 def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
@@ -274,7 +274,6 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
         out = monosrc.apply_3d_toeplitz_kernel(u, backend.rfftn(phi), backend=backend)
         
         # check that `adjAAu` and `out` are close to each other
-        #rel = backend.abs(adjAAu - out).max() / backend.sqrt((adjAAu**2).sum())
-        rel = backend.sqrt(((adjAAu - out)**2).sum()) / backend.sqrt((adjAAu**2).sum())
-        assert rel < tol*eps
-        
+        rel = utils._relerr_(adjAAu, out, backend=backend, notest=True)
+        assert rel < tol * eps
+

--- a/tests/test_3d_monosrc.py
+++ b/tests/test_3d_monosrc.py
@@ -1,24 +1,9 @@
-import pytest
 import pyepri.backends as backends
 import pyepri.monosrc as monosrc
 import importlib.util
 import numpy as np
 
-libname = ['numpy']
-
-if importlib.util.find_spec('torch') is not None:
-    import torch
-    libname += ['torch-cpu']
-    if torch.cuda.is_available():
-        libname += ['torch-cuda']
-if importlib.util.find_spec('cupy') is not None:
-    import cupy
-    libname += ['cupy']
-
-
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_proj3d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -63,11 +48,9 @@ def test_proj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
         # compare results
         rel = backend.sqrt((backend.abs(Ax1 - Ax2)**2).sum() / (backend.abs(Ax1)**2).sum())
         assert rel < tol*eps
-        
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -113,11 +96,9 @@ def test_backproj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
         # compare results
         rel = backend.sqrt((backend.abs(adjAy1 - adjAy2)**2).sum() / (backend.abs(adjAy1)**2).sum())
         assert rel < tol*eps
-        
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -160,11 +141,9 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         # compare results
         rel = backend.sqrt((backend.abs(phi1 - phi2)**2).sum() / (backend.abs(phi1)**2).sum())
         assert rel < tol*eps
-        
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns=100, tol=1000):
+
+def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -236,9 +215,7 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns=100, tol=1000):
     assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_3d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
+def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':

--- a/tests/test_3d_monosrc.py
+++ b/tests/test_3d_monosrc.py
@@ -24,17 +24,17 @@ def test_proj3d_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(15*backend.rand(1)[0])
-        N2 = 1 + int(15*backend.rand(1)[0])
-        N3 = 1 + int(15*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(15 * backend.rand(1)[0])
+        N2 = 1 + int(15 * backend.rand(1)[0])
+        N3 = 1 + int(15 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
@@ -71,17 +71,17 @@ def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(15*backend.rand(1)[0])
-        N2 = 1 + int(15*backend.rand(1)[0])
-        N3 = 1 + int(15*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(15 * backend.rand(1)[0])
+        N2 = 1 + int(15 * backend.rand(1)[0])
+        N3 = 1 + int(15 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
         B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
@@ -119,17 +119,17 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(15*backend.rand(1)[0])
-        N2 = 1 + int(15*backend.rand(1)[0])
-        N3 = 1 + int(15*backend.rand(1)[0])
-        Nproj = 1 + int(25*backend.rand(1)[0])
-        Nb = 2 + int(50*backend.rand(1)[0])
+        N1 = 1 + int(15 * backend.rand(1)[0])
+        N2 = 1 + int(15 * backend.rand(1)[0])
+        N3 = 1 + int(15 * backend.rand(1)[0])
+        Nproj = 1 + int(25 * backend.rand(1)[0])
+        Nb = 2 + int(50 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h1 = backend.rand(Nb, dtype=dtype)
         h2 = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(3, Nproj, dtype=dtype)
@@ -164,17 +164,17 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(15*backend.rand(1)[0])
-        Nb = 2 + int(40*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(15 * backend.rand(1)[0])
+        Nb = 2 + int(40 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
@@ -245,7 +245,7 @@ def test_proj2d_and_backproj2d_matrices(libname, dtype, nruns, tol):
             v[col-1] = 0
             v[col] = 1
             M[:,col] = arr_to_vec(A(vec_to_arr(v, (N1, N2, N3))))
-
+        
         # evaluate adjA(y) by matrix-vector multiplication
         Mt = backend.transpose(M)
         adjAy2 = vec_to_arr(Mt @ arr_to_vec(y), (N1, N2, N3))
@@ -276,17 +276,17 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(15*backend.rand(1)[0])
-        Nb = 2 + int(40*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(15 * backend.rand(1)[0])
+        Nb = 2 + int(40 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = backend.rand(Nb, dtype=dtype)
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
@@ -306,9 +306,6 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
         phi = monosrc.compute_3d_toeplitz_kernel(B, h, h, delta, fgrad, (2*N1, 2*N2, 2*N3), backend=backend, eps=eps, rfft_mode=rfft_mode, nodes=nodes)
         
         # apply 2D convolution
-        #u_large = backend.zeros([2*N1, 2*N2, 2*N3], dtype=backend.lib_to_str_dtypes[u.dtype])
-        #u_large[:N1, :N2, :N3] = u
-        #out = backend.irfftn(backend.rfftn(phi) * backend.rfftn(u_large), s=u_large.shape)[N1::,N2::,N3::]
         out = monosrc.apply_3d_toeplitz_kernel(u, backend.rfftn(phi), backend=backend)
         
         # check that `adjAAu` and `out` are close to each other

--- a/tests/test_3d_multisrc.py
+++ b/tests/test_3d_multisrc.py
@@ -1,6 +1,6 @@
 import pyepri.backends as backends
 import pyepri.multisrc as multisrc
-import importlib.util
+import pyepri.utils as utils
 import numpy as np
 
 def test_proj3d_rfftmode(libname, dtype, nruns, tol):
@@ -17,9 +17,6 @@ def test_proj3d_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.proj3d returns the same results whenever
     # rfft_mode parameter is True or False
@@ -53,9 +50,9 @@ def test_proj3d_rfftmode(libname, dtype, nruns, tol):
         Bu2 = multisrc.proj3d(u, delta, B, h, fgrad, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = [relerr(Bu1[i], Bu2[i]) for i in range(L)]
-        assert max(rel) < tol*eps
-        print("simu %d /%d : done" % (id+1, nruns))
+        rel = [utils._relerr_(Bu1[i], Bu2[i], backend=backend, notest=True) for i in range(L)]
+        assert max(rel) < tol * eps
+        print("simu %d /%d : done" % (id + 1, nruns))
 
 
 def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
@@ -72,9 +69,6 @@ def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.backproj3d returns the same results whenever
     # rfft_mode parameter is True or False
@@ -108,8 +102,8 @@ def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
         adjBs2 = multisrc.backproj3d(s, delta, B, h, fgrad, u_shape, backend=backend, rfft_mode=False, eps=eps)
         
         # compare results
-        rel = [relerr(adjBs1[j], adjBs2[j]) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(adjBs1[j], adjBs2[j], backend=backend, notest=True) for j in range(K)]
+        assert max(rel) < tol * eps
 
 
 def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
@@ -126,9 +120,6 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # retrieve machine epsilon
     eps = 1e-15 if dtype == 'float64' else 1e-6
-
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # check that multisrc.compute_3d_toeplitz_kernels returns the same
     # results whenever rfft_mode parameter is True or False
@@ -159,8 +150,8 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         phi2 = multisrc.compute_3d_toeplitz_kernels(B, h, delta, fgrad, u_shape, backend=backend, eps=eps, rfft_mode=False)
         
         # compare results
-        rel = [relerr(phi1[k][j], phi2[k][j]) for k in range(K) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(phi1[k][j], phi2[k][j], backend=backend, notest=True) for k in range(K) for j in range(K)]
+        assert max(rel) < tol * eps
 
 
 def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
@@ -217,8 +208,8 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
         # compute inner products
         inprod1 = sum([(Bu[i] * s[i]).sum() for i in range(L)])
         inprod2 = sum([(u[j] * adjBs[j]).sum() for j in range(K)])
-        rel = abs(1-inprod1/inprod2)
-        assert rel < tol*eps
+        rel = abs(1 - inprod1 / inprod2)
+        assert rel < tol * eps
 
 
 def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
@@ -235,9 +226,6 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # retrieve dtype precision (threshold to 1e-16)
     eps = 1e-15 if dtype == 'float64' else 1e-6
-    
-    # relative error computation macro
-    relerr = lambda arr1, arr2 : backend.sqrt(((arr1-arr2)**2).sum() / ((arr1)**2).sum())    
     
     # denoting by B and adjB the operators associated to
     # multisrc.proj3d and multisrc.backproj3d, check that adjB(B(u))
@@ -287,6 +275,6 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
         out = multisrc.apply_3d_toeplitz_kernels(u, rfft3_phi, backend=backend)
         
         # check that `adjBBu` and `out` are close to each other
-        rel = [relerr(adjBBu[j], out[j]) for j in range(K)]
-        assert max(rel) < tol*eps
+        rel = [utils._relerr_(adjBBu[j], out[j], backend=backend, notest=True) for j in range(K)]
+        assert max(rel) < tol * eps
         

--- a/tests/test_3d_multisrc.py
+++ b/tests/test_3d_multisrc.py
@@ -24,21 +24,22 @@ def test_proj3d_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(40*backend.rand(1)[0])
-        u_shape = [(1 + int(15*backend.rand(1)[0]), 1 +
-                    int(15*backend.rand(1)[0]), 1 + int(15*backend.rand(1)[0]))
+        Nb = 2 + int(40 * backend.rand(1)[0])
+        u_shape = [(1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]))
                    for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        s_shape = [(1 + int(20 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(3, s[0], dtype=dtype) for s in s_shape]
         
@@ -76,24 +77,25 @@ def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(40*backend.rand(1)[0])
-        u_shape = [(1 + int(15*backend.rand(1)[0]), 1 +
-                    int(15*backend.rand(1)[0]), 1 + int(15*backend.rand(1)[0]))
+        Nb = 2 + int(40 * backend.rand(1)[0])
+        u_shape = [(1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]))
                    for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        s_shape = [(1 + int(20 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * B0 + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(3, s[0], dtype=dtype) for s in s_shape]
-                
+        
         # sample random 3D projections
         s = [backend.rand(s[0], Nb, dtype=dtype) for s in s_shape]
         
@@ -127,21 +129,22 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(40*backend.rand(1)[0])
-        u_shape = [(1 + int(15*backend.rand(1)[0]), 1 +
-                    int(15*backend.rand(1)[0]), 1 + int(15*backend.rand(1)[0]))
+        Nb = 2 + int(40 * backend.rand(1)[0])
+        u_shape = [(1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]))
                    for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        s_shape = [(1 + int(20 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10 * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(3, s[0], dtype=dtype) for s in s_shape]
 
@@ -175,21 +178,22 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(50*backend.rand(1)[0])
-        u_shape = [(1 + int(15*backend.rand(1)[0]), 1 +
-                    int(15*backend.rand(1)[0]), 1 + int(15*backend.rand(1)[0]))
+        Nb = 2 + int(50 * backend.rand(1)[0])
+        u_shape = [(1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]),
+                    1 + int(16 * backend.rand(1)[0]))
                    for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        s_shape = [(1 + int(20 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(3, s[0], dtype=dtype) for s in s_shape]
         
@@ -236,21 +240,22 @@ def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
         
         # sample random number of sources and random number of
         # experiment
-        K = 1 + int(5*backend.rand(1)[0])
-        L = 1 + int(5*backend.rand(1)[0])
+        K = 1 + int(5 * backend.rand(1)[0])
+        L = 1 + int(5 * backend.rand(1)[0])
         
         # sample random dimensions
-        Nb = 2 + int(40*backend.rand(1)[0])
-        u_shape = [(1 + int(15*backend.rand(1)[0]), 1 +
-                    int(15*backend.rand(1)[0]), 1 + int(15*backend.rand(1)[0]))
+        Nb = 2 + int(40 * backend.rand(1)[0])
+        u_shape = [(1 + int(20 * backend.rand(1)[0]),
+                    1 + int(20 * backend.rand(1)[0]),
+                    1 + int(20 * backend.rand(1)[0]))
                    for j in range(K)]
-        s_shape = [(1 + int(25*backend.rand(1)[0]), Nb) for i in range(L)]
+        s_shape = [(1 + int(20 * backend.rand(1)[0]), Nb) for i in range(L)]
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         h = [[backend.rand(Nb, dtype=dtype) for j in range(K)] for i in range(L)]
         fgrad = [backend.rand(3, s[0], dtype=dtype) for s in s_shape]
         

--- a/tests/test_3d_multisrc.py
+++ b/tests/test_3d_multisrc.py
@@ -1,24 +1,9 @@
-import pytest
 import pyepri.backends as backends
 import pyepri.multisrc as multisrc
 import importlib.util
 import numpy as np
 
-libname = ['numpy']
-
-if importlib.util.find_spec('torch') is not None:
-    import torch
-    libname += ['torch-cpu']
-    if torch.cuda.is_available():
-        libname += ['torch-cuda']
-if importlib.util.find_spec('cupy') is not None:
-    import cupy
-    libname += ['cupy']
-
-
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_proj3d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -72,9 +57,8 @@ def test_proj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert max(rel) < tol*eps
         print("simu %d /%d : done" % (id+1, nruns))
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_backproj3d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -127,9 +111,8 @@ def test_backproj3d_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = [relerr(adjBs1[j], adjBs2[j]) for j in range(K)]
         assert max(rel) < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -179,9 +162,8 @@ def test_3d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = [relerr(phi1[k][j], phi2[k][j]) for k in range(K) for j in range(K)]
         assert max(rel) < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns=100, tol=1000):
+
+def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -238,9 +220,8 @@ def test_proj3d_and_backproj3d_adjointness(libname, dtype, nruns=100, tol=1000):
         rel = abs(1-inprod1/inprod2)
         assert rel < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_3d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
+
+def test_3d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':

--- a/tests/test_4d_spectralspatial.py
+++ b/tests/test_4d_spectralspatial.py
@@ -1,23 +1,9 @@
-import pytest
 import pyepri.backends as backends
 import pyepri.spectralspatial as ss
 import importlib.util
 import numpy as np
 
-libname = ['numpy']
-
-if importlib.util.find_spec('torch') is not None:
-    import torch
-    libname += ['torch-cpu']
-    if torch.cuda.is_available():
-        libname += ['torch-cuda']
-if importlib.util.find_spec('cupy') is not None:
-    import cupy
-    libname += ['cupy']
-
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_proj4d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -42,14 +28,14 @@ def test_proj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -67,9 +53,8 @@ def test_proj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
         rel = relerr(Ax1, Ax2, nrm=nrm)
         assert rel < tol*eps
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
+
+def test_proj4d_memory_usage(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -94,14 +79,14 @@ def test_proj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -121,10 +106,9 @@ def test_proj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
         rel2 = relerr(Ax0, Ax2, nrm=nrm)
         rel = max(rel1, rel2)
         assert rel < tol*eps
-        
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
+
+
+def test_backproj4d_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -149,14 +133,14 @@ def test_backproj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -176,9 +160,7 @@ def test_backproj4d_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_backproj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
+def test_backproj4d_memory_usage(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -203,14 +185,14 @@ def test_backproj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -233,9 +215,7 @@ def test_backproj4d_memory_usage(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -260,14 +240,14 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -281,11 +261,9 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         nrm = 1. / backend.abs(phi1).max().item()
         rel = relerr(phi1, phi2, nrm=nrm)
         assert rel < tol*eps
-        
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj4d_and_backproj4d_adjointness(libname, dtype, nruns=100, tol=1000):
+
+def test_proj4d_and_backproj4d_adjointness(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -306,14 +284,14 @@ def test_proj4d_and_backproj4d_adjointness(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -334,10 +312,9 @@ def test_proj4d_and_backproj4d_adjointness(libname, dtype, nruns=100, tol=1000):
         inprod2 = (x * adjAy).sum()
         rel = abs(1 - inprod1 / inprod2)
         assert rel < tol*eps
-        
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_proj4d_and_backproj4d_matrices(libname, dtype, nruns=10, tol=1000):
+
+
+def test_proj4d_and_backproj4d_matrices(libname, dtype, nruns, tol):
 
     # create backend
     if libname == 'numpy':
@@ -362,12 +339,12 @@ def test_proj4d_and_backproj4d_matrices(libname, dtype, nruns=10, tol=1000):
     for id in range(nruns):
     
         # compute a very small dataset
-        N1 = 1 + int(4*backend.rand(1)[0])
-        N2 = 1 + int(4*backend.rand(1)[0])
-        N3 = 1 + int(4*backend.rand(1)[0])
-        Nproj = 1 + int(5*backend.rand(1)[0])
-        Nb = 2 + int(5*backend.rand(1)[0])
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        N1 = 1 + int(4 * backend.rand(1)[0])
+        N2 = 1 + int(4 * backend.rand(1)[0])
+        N3 = 1 + int(4 * backend.rand(1)[0])
+        Nproj = 1 + int(5 * backend.rand(1)[0])
+        Nb = 2 + int(5 * backend.rand(1)[0])
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -399,9 +376,7 @@ def test_proj4d_and_backproj4d_matrices(libname, dtype, nruns=10, tol=1000):
         assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", ['numpy'])
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
+def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -426,14 +401,14 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -449,9 +424,7 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", ['numpy'])
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_4d_toeplitz_kernel_memory_usage(libname, dtype, nruns=100, tol=1000):
+def test_4d_toeplitz_kernel_memory_usage(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -476,14 +449,14 @@ def test_4d_toeplitz_kernel_memory_usage(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB
@@ -499,9 +472,7 @@ def test_4d_toeplitz_kernel_memory_usage(libname, dtype, nruns=100, tol=1000):
         assert rel < tol*eps
 
 
-@pytest.mark.parametrize("libname", libname)
-@pytest.mark.parametrize("dtype", ['float32', 'float64'])
-def test_4d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
+def test_4d_toeplitz_kernel(libname, dtype, nruns, tol):
     
     # create backend
     if libname == 'numpy':
@@ -528,14 +499,14 @@ def test_4d_toeplitz_kernel(libname, dtype, nruns=100, tol=1000):
     for id in range(nruns):
         
         # sample random dimensions 
-        N1 = 1 + int(10*backend.rand(1)[0])
-        N2 = 1 + int(10*backend.rand(1)[0])
-        N3 = 1 + int(10*backend.rand(1)[0])
-        Nproj = 1 + int(10*backend.rand(1)[0])
-        Nb = 2 + int(10*backend.rand(1)[0])
+        N1 = 1 + int(10 * backend.rand(1)[0])
+        N2 = 1 + int(10 * backend.rand(1)[0])
+        N3 = 1 + int(10 * backend.rand(1)[0])
+        Nproj = 1 + int(10 * backend.rand(1)[0])
+        Nb = 2 + int(10 * backend.rand(1)[0])
         
         # sample random inputs 
-        B0 = backend.cast(200+100*backend.rand(1)[0], dtype)
+        B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
         B = B0 + backend.arange(Nb, dtype=dtype)*dB

--- a/tests/test_4d_spectralspatial.py
+++ b/tests/test_4d_spectralspatial.py
@@ -323,12 +323,12 @@ def test_proj4d_and_backproj4d_matrices(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         x = backend.rand(Nb, N1, N2, N3, dtype=dtype)
         y = backend.rand(Nproj, Nb, dtype=dtype)
         
-        # compute matricial representation of A and its adjoint (use a very small dataset)
+        # compute matricial representation of A and its adjoint over this dataset
         A = lambda x : ss.proj4d(x, delta, B, fgrad, backend=backend, rfft_mode=True, eps=eps)
         arr_to_vec = lambda arr : arr.reshape((-1,))
         vec_to_arr = lambda vec, shape: vec.reshape(shape)

--- a/tests/test_4d_spectralspatial.py
+++ b/tests/test_4d_spectralspatial.py
@@ -34,7 +34,7 @@ def test_proj4d_rfftmode(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random 4D image
@@ -80,7 +80,7 @@ def test_proj4d_memory_usage(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random 4D image
@@ -130,7 +130,7 @@ def test_backproj4d_rfftmode(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random 4D projections
@@ -177,7 +177,7 @@ def test_backproj4d_memory_usage(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random 4D projections
@@ -231,7 +231,7 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # compute Toeplitz kernel (with rfft_mode enabled or not)
@@ -274,7 +274,7 @@ def test_proj4d_and_backproj4d_adjointness(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random signals (x=image, y=projections)
@@ -382,7 +382,7 @@ def test_4d_toeplitz_kernel_rfftmode(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # compute Toeplitz kernel (with rfft_mode enabled or not)
@@ -425,7 +425,7 @@ def test_4d_toeplitz_kernel_memory_usage(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # compute Toeplitz kernel (with rfft_mode enabled or not)
@@ -470,7 +470,7 @@ def test_4d_toeplitz_kernel(libname, dtype, nruns, tol):
         B0 = backend.cast(200 + 100 * backend.rand(1)[0], dtype)
         dB = 10. * B0 * eps + backend.rand(1, dtype=dtype)[0]
         delta = float(10. * eps + backend.rand(1)[0])
-        B = B0 + backend.arange(Nb, dtype=dtype)*dB
+        B = B0 + backend.arange(Nb, dtype=dtype) * dB
         fgrad = backend.rand(3, Nproj, dtype=dtype)
         
         # sample random image


### PR DESCRIPTION
- removed pytest parametrization (dtype and libname) and added custom inputs instead (dtype, libname, nruns, tol) using ``conftest.py`` file

- added ``pyepri.utils._relerr_`` function to compute the relative error between two (renormalized) arrays and replaced duplicate lambda functions

- added specific adjointness test using matricial representations in all test files

- made some minor changes (mainly formatting)